### PR TITLE
Backfill entries further into the past

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 
 build
 dist
+.history/**
+.venv/**

--- a/aw_watcher_toggl/main.py
+++ b/aw_watcher_toggl/main.py
@@ -133,11 +133,9 @@ def main():
     token = config["aw-watcher-toggl"].get("api_token", None)
     backfill = config["aw-watcher-toggl"].get("backfill", False)
     backfill_since = config["aw-watcher-toggl"].get("backfill_since", None)
-    backfill_since = (
-        datetime.strptime(backfill_since, "%Y-%m-%d")
-        if backfill_since
-        else datetime.now() - timedelta(days=32)
-    ).replace(day=1)
+    backfill_since = (backfill_since or datetime.now() - timedelta(days=32)).replace(
+        day=1
+    )
 
     update_existing_events = config["aw-watcher-toggl"].get(
         "update_existing_events", False

--- a/aw_watcher_toggl/main.py
+++ b/aw_watcher_toggl/main.py
@@ -3,7 +3,6 @@
 import sys
 import logging
 import traceback
-from typing import Optional
 from time import sleep
 from datetime import datetime, timezone, timedelta
 from calendar import monthrange
@@ -43,10 +42,11 @@ def get_time_entries(api_token, month: datetime = None):
 
     return response.json()
 
+
 def get_current_time_entry(api_token):
-    auth = (api_token, 'api_token')
+    auth = (api_token, "api_token")
     url = "https://api.track.toggl.com/api/v9/me/time_entries/current"
-    headers = {'Content-Type': 'application/json'}
+    headers = {"Content-Type": "application/json"}
     response = requests.get(url=url, auth=auth, headers=headers, timeout=5)
 
     if response.status_code != 200:
@@ -54,16 +54,18 @@ def get_current_time_entry(api_token):
 
     return response.json()
 
+
 def get_projects(api_token):
-    auth = (api_token, 'api_token')
-    url = 'https://api.track.toggl.com/api/v9/me/projects'
-    headers = {'Content-Type': 'application/json'}
+    auth = (api_token, "api_token")
+    url = "https://api.track.toggl.com/api/v9/me/projects"
+    headers = {"Content-Type": "application/json"}
     response = requests.get(url, auth=auth, headers=headers, timeout=5)
 
     if response.status_code != 200:
         raise requests.exceptions.HTTPError(response.text)
 
     return {proj["id"]: proj["name"] for proj in response.json()}
+
 
 def process_time_entries(aw, bucketname, entries, projects, update_existing_events):
     already_logged_events = defaultdict(list)
@@ -108,7 +110,9 @@ def process_time_entries(aw, bucketname, entries, projects, update_existing_even
 
 def load_config():
     from aw_core.config import load_config_toml as _load_config
+
     return _load_config("aw-watcher-toggl", DEFAULT_CONFIG)
+
 
 def print_statusline(msg):
     last_msg_length = (
@@ -117,6 +121,7 @@ def print_statusline(msg):
     print(" " * last_msg_length, end="\r")
     print(msg, end="\r")
     print_statusline.last_msg = msg
+
 
 def main():
     logging.basicConfig(level=logging.INFO)
@@ -204,10 +209,16 @@ def main():
 
         try:
             if entry:
-                data = {"project": projects[entry["project_id"]] if entry["project_id"] is not None else "No project",
-                        "title": entry["description"] if entry["description"] != "" else "No Name" , 
-                        "tags":str(entry["tags"]), 
-                        "uid": entry["id"]}
+                data = {
+                    "project": projects[entry["project_id"]]
+                    if entry["project_id"] is not None
+                    else "No project",
+                    "title": entry["description"]
+                    if entry["description"] != ""
+                    else "No Name",
+                    "tags": str(entry["tags"]),
+                    "uid": entry["id"],
+                }
                 print_statusline(f"Active Entry: {data['title']}")
                 event = Event(timestamp=datetime.now(timezone.utc), data=data)
                 aw.heartbeat(bucketname, event, pulsetime=poll_time + 5, queued=True)

--- a/aw_watcher_toggl/main.py
+++ b/aw_watcher_toggl/main.py
@@ -26,16 +26,15 @@ backfill = false
 update_existing_events = true"""
 
 
-def get_time_entries(api_token):
-    now = datetime.now()
+def get_time_entries(api_token, month: datetime = None):
+    month = month or datetime.now()
 
     # Calculate the first day of the last month
-    last_month_first_day = datetime(now.year, now.month - 1, 1) if now.month > 1 else datetime(now.year - 1, 12, 1)
-    formatted_first_day_last_month = last_month_first_day.strftime('%Y-%m-%d')
-    formatted_now = now.strftime('%Y-%m-%d')
-    auth = (api_token, 'api_token')
-    url = f'https://api.track.toggl.com/api/v9/me/time_entries?start_date={formatted_first_day_last_month}&end_date={formatted_now}'
-    headers = {'Content-Type': 'application/json'}
+    month_first_day = month.replace(day=1)
+    month_last_day = month.replace(day=monthrange(month.year, month.month)[1])
+    auth = (api_token, "api_token")
+    url = f"https://api.track.toggl.com/api/v9/me/time_entries?start_date={month_first_day.strftime('%Y-%m-%d')}&end_date={month_last_day.strftime('%Y-%m-%d')}"
+    headers = {"Content-Type": "application/json"}
     response = requests.get(url=url, auth=auth, headers=headers, timeout=5)
 
     if response.status_code != 200:


### PR DESCRIPTION
- Allows backfilling of entries from Toggl from a configured date (`backfill_since`)
- Prefix the project name to the AW event title. This handles the case where empty descriptions would not insert the event into AW